### PR TITLE
print package name checked

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -23,6 +23,6 @@ if (cli.input.length === 0) {
 }
 
 npmName(cli.input[0]).then(available => {
-	console.log(available ? `${logSymbols.success} Available` : `${logSymbols.error} Unavailable`);
+	console.log(available ? `${logSymbols.success} "${cli.input[0]}" is available` : `${logSymbols.error} "${cli.input[0]}" is unavailable`);
 	process.exit(available ? 0 : 2);
 });

--- a/test.js
+++ b/test.js
@@ -2,8 +2,8 @@ import childProcess from 'child_process';
 import test from 'ava';
 import pify from 'pify';
 import logSymbols from 'log-symbols';
-
 test(async t => {
-	const stdout = await pify(childProcess.execFile)('./cli.js', ['unicorn-rainbow-2524342', '--color'], {cwd: __dirname});
-	t.is(stdout.trim(), `${logSymbols.success} Available`);
+	const rand = `asdasfgrgafadsgaf + ${Math.random().toString().slice(2)}`;
+	const stdout = await pify(childProcess.execFile)('./cli.js', [rand, '--color'], {cwd: __dirname});
+	t.is(stdout.trim(), `${logSymbols.success} "${rand}" is available`);
 });

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ import childProcess from 'child_process';
 import test from 'ava';
 import pify from 'pify';
 import logSymbols from 'log-symbols';
+
 test(async t => {
 	const rand = `asdasfgrgafadsgaf + ${Math.random().toString().slice(2)}`;
 	const stdout = await pify(childProcess.execFile)('./cli.js', [rand, '--color'], {cwd: __dirname});


### PR DESCRIPTION
Instead of 
> Available

or
> Unavailable

for example when calling `npm-name express`, it would be
> "express" is unavailable

And the same is true for available
> "adjkoiuytewxcbnmkgfert" is available