### PR TITLE
Add ability to specify multiple names

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -20,7 +20,11 @@ const cli = meow(`
 	string: ['_']
 });
 
-const input = cli.input[0];
+let input = cli.input[0];
+
+if (input.indexOf(',') > -1) {
+	input = input.split(',');
+}
 
 if (!input) {
 	console.error('Package name required');
@@ -28,7 +32,22 @@ if (!input) {
 }
 
 npmName(input).then(available => {
+	let exitWithError = available;
+
+	if (available instanceof Array) {
+		for (let i = 0, len = available.length; i < len; i++) {
+			outputStatus(input[i], available[i]);
+		}
+
+		exitWithError = available.indexOf(false) > -1;
+	} else {
+		outputStatus(input, available);
+	}
+
+	process.exit(exitWithError ? 0 : 2);
+});
+
+function outputStatus(input, available) {
 	const name = chalk.bold(input);
 	console.log(available ? `${logSymbols.success} ${name} is available` : `${logSymbols.error} ${name} is unavailable`);
-	process.exit(available ? 0 : 2);
-});
+}

--- a/cli.js
+++ b/cli.js
@@ -7,16 +7,16 @@ const npmName = require('npm-name');
 
 const cli = meow(`
 	Usage
-	  $ npm-name <name>
+		$ npm-name <name>
 
 	Examples
-	  $ npm-name chalk
-	  ${logSymbols.error} ${chalk.bold('chalk')} is unavailable
-	  $ npm-name unicorn-cake
-	  ${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
-	  $ npm-name chalk unicorn-cake
-	  ${logSymbols.error} ${chalk.bold('chalk')} is unavailable
-	  ${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
+		$ npm-name chalk
+		${logSymbols.error} ${chalk.bold('chalk')} is unavailable
+		$ npm-name unicorn-cake
+		${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
+		$ npm-name chalk unicorn-cake
+		${logSymbols.error} ${chalk.bold('chalk')} is unavailable
+		${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
 
 	Exits with code 0 when the name is available or 2 when taken
 `, {
@@ -30,10 +30,10 @@ if (!input) {
 	process.exit(1);
 }
 
-npmName(input).then(available => {
-  input.forEach((name, indx) => {
-    outputStatus(name, available[indx]);
-  });
+npmName.many(input).then(available => {
+	input.forEach((name, indx) => {
+		outputStatus(name, available[indx]);
+	});
 
 	process.exit(available.indexOf(false) > -1 ? 2 : 0);
 });

--- a/cli.js
+++ b/cli.js
@@ -6,48 +6,51 @@ const chalk = require('chalk');
 const npmName = require('npm-name');
 
 const cli = meow(`
-	Usage
-	  $ npm-name <name>
+  Usage
+    $ npm-name <name>
 
-	Examples
-	  $ npm-name chalk
-	  ${logSymbols.error} ${chalk.bold('chalk')} is unavailable
-	  $ npm-name unicorn-cake
-	  ${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
+  Examples
+    $ npm-name chalk
+    ${logSymbols.error} ${chalk.bold('chalk')} is unavailable
+    $ npm-name unicorn-cake
+    ${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
+    $ npm-name chalk,unicorn-cake
+    ${logSymbols.error} ${chalk.bold('chalk')} is unavailable
+    ${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
 
-	Exits with code 0 when the name is available or 2 when taken
+  Exits with code 0 when the name is available or 2 when taken
 `, {
-	string: ['_']
+  string: ['_']
 });
 
 let input = cli.input[0];
 
 if (input.indexOf(',') > -1) {
-	input = input.split(',');
+  input = input.split(',');
 }
 
 if (!input) {
-	console.error('Package name required');
-	process.exit(1);
+  console.error('Package name required');
+  process.exit(1);
 }
 
 npmName(input).then(available => {
-	let exitWithError = available;
+  let exitWithError = available;
 
-	if (available instanceof Array) {
-		for (let i = 0, len = available.length; i < len; i++) {
-			outputStatus(input[i], available[i]);
-		}
+  if (available instanceof Array) {
+    for (let i = 0, len = available.length; i < len; i++) {
+      outputStatus(input[i], available[i]);
+    }
 
-		exitWithError = available.indexOf(false) > -1;
-	} else {
-		outputStatus(input, available);
-	}
+    exitWithError = available.indexOf(false) > -1;
+  } else {
+    outputStatus(input, available);
+  }
 
-	process.exit(exitWithError ? 0 : 2);
+  process.exit(exitWithError ? 0 : 2);
 });
 
 function outputStatus(input, available) {
-	const name = chalk.bold(input);
-	console.log(available ? `${logSymbols.success} ${name} is available` : `${logSymbols.error} ${name} is unavailable`);
+  const name = chalk.bold(input);
+  console.log(available ? `${logSymbols.success} ${name} is available` : `${logSymbols.error} ${name} is unavailable`);
 }

--- a/cli.js
+++ b/cli.js
@@ -7,38 +7,44 @@ const npmName = require('npm-name');
 
 const cli = meow(`
 	Usage
-		$ npm-name <name>
+	  $ npm-name <name> ...
 
 	Examples
-		$ npm-name chalk
-		${logSymbols.error} ${chalk.bold('chalk')} is unavailable
-		$ npm-name unicorn-cake
-		${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
-		$ npm-name chalk unicorn-cake
-		${logSymbols.error} ${chalk.bold('chalk')} is unavailable
-		${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
+	  $ npm-name chalk
+	  ${logSymbols.error} ${chalk.bold('chalk')} is unavailable
+	  $ npm-name unicorn-cake
+	  ${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
+	  $ npm-name chalk unicorn-cake
+	  ${logSymbols.error} ${chalk.bold('chalk')} is unavailable
+	  ${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
 
-	Exits with code 0 when the name is available or 2 when taken
+	Exits with code 0 when all names are available or 2 when any names are taken
 `, {
 	string: ['_']
 });
 
 const input = cli.input;
 
-if (!input) {
+if (input.length === 0) {
 	console.error('Package name required');
 	process.exit(1);
 }
 
 npmName.many(input).then(available => {
-	input.forEach((name, indx) => {
-		outputStatus(name, available[indx]);
-	});
+	available.forEach(outputStatus);
 
-	process.exit(available.indexOf(false) > -1 ? 2 : 0);
+	let hasFalseValue = false;
+	for (const i of available.values()) {
+		if (!i) {
+			hasFalseValue = true;
+			break;
+		}
+	}
+
+	process.exit(hasFalseValue ? 2 : 0);
 });
 
-function outputStatus(input, available) {
-	const name = chalk.bold(input);
-	console.log(available ? `${logSymbols.success} ${name} is available` : `${logSymbols.error} ${name} is unavailable`);
+function outputStatus(value, key) {
+	const name = chalk.bold(key);
+	console.log(value ? `${logSymbols.success} ${name} is available` : `${logSymbols.error} ${name} is unavailable`);
 }

--- a/cli.js
+++ b/cli.js
@@ -6,51 +6,39 @@ const chalk = require('chalk');
 const npmName = require('npm-name');
 
 const cli = meow(`
-  Usage
-    $ npm-name <name>
+	Usage
+	  $ npm-name <name>
 
-  Examples
-    $ npm-name chalk
-    ${logSymbols.error} ${chalk.bold('chalk')} is unavailable
-    $ npm-name unicorn-cake
-    ${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
-    $ npm-name chalk,unicorn-cake
-    ${logSymbols.error} ${chalk.bold('chalk')} is unavailable
-    ${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
+	Examples
+	  $ npm-name chalk
+	  ${logSymbols.error} ${chalk.bold('chalk')} is unavailable
+	  $ npm-name unicorn-cake
+	  ${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
+	  $ npm-name chalk unicorn-cake
+	  ${logSymbols.error} ${chalk.bold('chalk')} is unavailable
+	  ${logSymbols.success} ${chalk.bold('unicorn-cake')} is available
 
-  Exits with code 0 when the name is available or 2 when taken
+	Exits with code 0 when the name is available or 2 when taken
 `, {
-  string: ['_']
+	string: ['_']
 });
 
-let input = cli.input[0];
-
-if (input.indexOf(',') > -1) {
-  input = input.split(',');
-}
+const input = cli.input;
 
 if (!input) {
-  console.error('Package name required');
-  process.exit(1);
+	console.error('Package name required');
+	process.exit(1);
 }
 
 npmName(input).then(available => {
-  let exitWithError = available;
+  input.forEach((name, indx) => {
+    outputStatus(name, available[indx]);
+  });
 
-  if (available instanceof Array) {
-    for (let i = 0, len = available.length; i < len; i++) {
-      outputStatus(input[i], available[i]);
-    }
-
-    exitWithError = available.indexOf(false) > -1;
-  } else {
-    outputStatus(input, available);
-  }
-
-  process.exit(exitWithError ? 0 : 2);
+	process.exit(available.indexOf(false) > -1 ? 2 : 0);
 });
 
 function outputStatus(input, available) {
-  const name = chalk.bold(input);
-  console.log(available ? `${logSymbols.success} ${name} is available` : `${logSymbols.error} ${name} is unavailable`);
+	const name = chalk.bold(input);
+	console.log(available ? `${logSymbols.success} ${name} is available` : `${logSymbols.error} ${name} is unavailable`);
 }

--- a/cli.js
+++ b/cli.js
@@ -32,16 +32,7 @@ if (input.length === 0) {
 
 npmName.many(input).then(available => {
 	available.forEach(outputStatus);
-
-	let hasFalseValue = false;
-	for (const i of available.values()) {
-		if (!i) {
-			hasFalseValue = true;
-			break;
-		}
-	}
-
-	process.exit(hasFalseValue ? 2 : 0);
+	process.exit(Array.from(available.values()).every(Boolean) ? 0 : 2);
 });
 
 function outputStatus(value, key) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chalk": "^1.1.1",
     "log-symbols": "^1.0.2",
     "meow": "^3.4.2",
-    "npm-name": "^2.0.0"
+    "npm-name": "^3.0.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "xo": "*"
   },
   "xo": {
-    "esnext": true,
-    "space": true
+    "esnext": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "xo": "*"
   },
   "xo": {
-    "esnext": true
+    "esnext": true,
+    "space": true
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -18,13 +18,18 @@ $ npm install --global npm-name-cli
 $ npm-name --help
 
   Usage
-    $ npm-name <name>
+    $ npm-name <names>
 
   Examples
     $ npm-name chalk
     ✖ chalk is unavailable
+
     $ npm-name unicorn-cake
     ✔ unicorn-cake is available
+
+		$ npm-name chalk,unicorn-cake
+		✖ chalk is unavailable
+		✔ unicorn-cake is available
 
   Exits with code 0 when the name is available or 2 when taken
 ```

--- a/readme.md
+++ b/readme.md
@@ -17,19 +17,19 @@ $ npm install --global npm-name-cli
 ```
 $ npm-name --help
 
-  Usage
-    $ npm-name <names>
+	Usage
+	  $ npm-name <name> ...
 
-  Examples
-    $ npm-name chalk
-    ✖ chalk is unavailable
-    $ npm-name unicorn-cake
-    ✔ unicorn-cake is available
-    $ npm-name chalk,unicorn-cake
-    ✖ chalk is unavailable
-    ✔ unicorn-cake is available
+	Examples
+	  $ npm-name chalk
+	  ✖ chalk is unavailable
+	  $ npm-name unicorn-cake
+	  ✔ unicorn-cake is available
+	  $ npm-name chalk unicorn-cake
+	  ✖ chalk is unavailable
+	  ✔ unicorn-cake is available
 
-  Exits with code 0 when the name is available or 2 when taken
+	Exits with code 0 when all names are available or 2 when any names are taken
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -23,13 +23,11 @@ $ npm-name --help
   Examples
     $ npm-name chalk
     ✖ chalk is unavailable
-
     $ npm-name unicorn-cake
     ✔ unicorn-cake is available
-
-		$ npm-name chalk,unicorn-cake
-		✖ chalk is unavailable
-		✔ unicorn-cake is available
+    $ npm-name chalk,unicorn-cake
+    ✖ chalk is unavailable
+    ✔ unicorn-cake is available
 
   Exits with code 0 when the name is available or 2 when taken
 ```

--- a/test.js
+++ b/test.js
@@ -1,31 +1,21 @@
 import test from 'ava';
 import execa from 'execa';
 
-function randomName() {
-	return `asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
-}
+const randomName = () => `asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
 
-test(async t => {
+test('is available', async t => {
 	const ret = await execa('./cli.js', [randomName(), '--color'], {cwd: __dirname});
 	t.regex(ret.stdout, /is available/);
 });
 
-test(async t => {
-	const pkgName = 'chalk';
-	try {
-		const ret = await execa('./cli.js', [pkgName, '--color'], {cwd: __dirname});
-		t.regex(ret.stdout, /is unavailable/);
-	} catch (err) {
-		t.ok(err);
-	}
+test('is unavailable', async t => {
+	const ret = await t.throws(execa('./cli.js', ['chalk', '--color'], {cwd: __dirname}));
+	t.is(ret.code, 2);
+	t.regex(ret.stdout, /is unavailable/);
 });
 
-test(async t => {
-	const pkgName = 'chalk';
-	try {
-		const ret = await execa('./cli.js', [pkgName, randomName(), '--color'], {cwd: __dirname});
-		t.regex(ret.stdout, /is unavailable([\s\S]*)is available/);
-	} catch (err) {
-		t.ok(err);
-	}
+test('multiple packages', async t => {
+	const ret = await t.throws(execa('./cli.js', ['chalk', randomName(), '--color'], {cwd: __dirname}));
+	t.is(ret.code, 2);
+	t.regex(ret.stdout, /is unavailable([\s\S]*)is available/);
 });

--- a/test.js
+++ b/test.js
@@ -1,9 +1,12 @@
 import test from 'ava';
 import execa from 'execa';
 
+function randomName() {
+	return `asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
+}
+
 test(async t => {
-	const pkgName = `asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
-	const ret = await execa('./cli.js', [pkgName, '--color'], {cwd: __dirname});
+	const ret = await execa('./cli.js', [randomName(), '--color'], {cwd: __dirname});
 	t.regex(ret.stdout, /is available/);
 });
 
@@ -18,10 +21,9 @@ test(async t => {
 });
 
 test(async t => {
-	const pkgName1 = 'chalk';
-	const pkgName2 = `asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
+	const pkgName = 'chalk';
 	try {
-		const ret = await execa('./cli.js', [pkgName1, pkgName2, '--color'], {cwd: __dirname});
+		const ret = await execa('./cli.js', [pkgName, randomName(), '--color'], {cwd: __dirname});
 		t.regex(ret.stdout, /is unavailable([\s\S]*)is available/);
 	} catch (err) {
 		t.ok(err);

--- a/test.js
+++ b/test.js
@@ -2,13 +2,28 @@ import test from 'ava';
 import execa from 'execa';
 
 test(async t => {
-  const pkgName = `asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
-  const ret = await execa('./cli.js', [pkgName, '--color'], {cwd: __dirname});
-  t.regex(ret.stdout, /is available/);
+	const pkgName = `asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
+	const ret = await execa('./cli.js', [pkgName, '--color'], {cwd: __dirname});
+	t.regex(ret.stdout, /is available/);
 });
 
 test(async t => {
-  const pkgName = `chalk,asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
-  const ret = await execa('./cli.js', [pkgName, '--color'], {cwd: __dirname});
-  t.regex(ret.stdout, /is unavailable([\s\S]*)is available/);
+	const pkgName = 'chalk';
+	try {
+		const ret = await execa('./cli.js', [pkgName, '--color'], {cwd: __dirname});
+		t.regex(ret.stdout, /is unavailable/);
+	} catch (err) {
+		t.ok(err)
+	}
+});
+
+test(async t => {
+	const pkgName1 = 'chalk'
+	const pkgName2 = `asdasfgrgafadsgaf${Math.random().toString().slice(2)}`
+	try {
+		const ret = await execa('./cli.js', [pkgName1, pkgName2, '--color'], {cwd: __dirname});
+		t.regex(ret.stdout, /is unavailable([\s\S]*)is available/);
+	} catch (err) {
+		t.ok(err)
+	}
 });

--- a/test.js
+++ b/test.js
@@ -2,13 +2,13 @@ import test from 'ava';
 import execa from 'execa';
 
 test(async t => {
-	const pkgName = `asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
-	const ret = await execa('./cli.js', [pkgName, '--color'], {cwd: __dirname});
-	t.regex(ret.stdout, /is available/);
+  const pkgName = `asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
+  const ret = await execa('./cli.js', [pkgName, '--color'], {cwd: __dirname});
+  t.regex(ret.stdout, /is available/);
 });
 
 test(async t => {
-	const pkgName = `chalk,asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
-	const ret = await execa('./cli.js', [pkgName, '--color'], {cwd: __dirname});
-	t.regex(ret.stdout, /is unavailable([\s\S]*)is available/);
+  const pkgName = `chalk,asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
+  const ret = await execa('./cli.js', [pkgName, '--color'], {cwd: __dirname});
+  t.regex(ret.stdout, /is unavailable([\s\S]*)is available/);
 });

--- a/test.js
+++ b/test.js
@@ -6,3 +6,9 @@ test(async t => {
 	const ret = await execa('./cli.js', [pkgName, '--color'], {cwd: __dirname});
 	t.regex(ret.stdout, /is available/);
 });
+
+test(async t => {
+	const pkgName = `chalk,asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
+	const ret = await execa('./cli.js', [pkgName, '--color'], {cwd: __dirname});
+	t.regex(ret.stdout, /is unavailable([\s\S]*)is available/);
+});

--- a/test.js
+++ b/test.js
@@ -13,17 +13,17 @@ test(async t => {
 		const ret = await execa('./cli.js', [pkgName, '--color'], {cwd: __dirname});
 		t.regex(ret.stdout, /is unavailable/);
 	} catch (err) {
-		t.ok(err)
+		t.ok(err);
 	}
 });
 
 test(async t => {
-	const pkgName1 = 'chalk'
-	const pkgName2 = `asdasfgrgafadsgaf${Math.random().toString().slice(2)}`
+	const pkgName1 = 'chalk';
+	const pkgName2 = `asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
 	try {
 		const ret = await execa('./cli.js', [pkgName1, pkgName2, '--color'], {cwd: __dirname});
 		t.regex(ret.stdout, /is unavailable([\s\S]*)is available/);
 	} catch (err) {
-		t.ok(err)
+		t.ok(err);
 	}
 });


### PR DESCRIPTION
Goes alongside https://github.com/sindresorhus/npm-name/pull/8 to allow multiple names with a single command. This lets you pass in comma seperated names. e.g. `npm-name chalk,abc123`.