### PR TITLE
Add squatter detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "chalk": "^1.1.1",
     "log-symbols": "^1.0.2",
     "meow": "^3.4.2",
-    "npm-name": "^3.0.0"
+    "npm-name": "^3.0.0",
+    "squatter": "^0.1.1"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,8 @@ $ npm-name --help
   Examples
     $ npm-name chalk
     ✖ chalk is unavailable
+    $ npm-name foo
+    ⚠ foo is squatted
     $ npm-name unicorn-cake
     ✔ unicorn-cake is available
     $ npm-name chalk unicorn-cake
@@ -39,9 +41,11 @@ $ npm-name --help
 
 1. Nicer & simpler output
 
-2. [npm search is only supported on npm 4](https://github.com/npm/npm/issues/14649#issuecomment-262820415), which is not yet bundled with Node.js
+2. [npm search is only supported on npm 4](https://github.com/npm/npm/issues/14649#issuecomment-262820415), which is only bundled with Node.js 7.4+
 
-3. Performance
+3. [Squatter detection](https://github.com/sholladay/squatter)
+
+4. Performance
 
   Using npm 4.0.2
 
@@ -49,7 +53,7 @@ $ npm-name --help
   $ time npm search unicorn-cake
   No matches found for "unicorn-cake"
   npm search unicorn-cake  55.50s user 0.82s system 101% cpu 55.380 total
-  $ time npm-name unicorn-cake  
+  $ time npm-name unicorn-cake
   ✔ unicorn-cake is available
   npm-name unicorn-cake  0.17s user 0.02s system 35% cpu 0.535 total
   ```

--- a/test.js
+++ b/test.js
@@ -8,6 +8,11 @@ test('is available', async t => {
 	t.regex(ret.stdout, /is available/);
 });
 
+test('is squatted', async t => {
+	const ret = await execa('./cli.js', ['foo', '--color'], {cwd: __dirname});
+	t.regex(ret.stdout, /is squatted/);
+});
+
 test('is unavailable', async t => {
 	const ret = await t.throws(execa('./cli.js', ['chalk', '--color'], {cwd: __dirname}));
 	t.is(ret.code, 2);


### PR DESCRIPTION
Fixes #5 by implementing [sholladay/squatter](https://github.com/sholladay/squatter) and logging a warning for squatters, exiting code zero. Previously, we would exit with the "is unavailable" error. This makes the CLI more useful, as I believe that most people are willing to ask for a package name if it is not _really_ being used.

The only downside I could think of is a theoretical scenario where someone were using this CLI in a script and wanted to distinguish between the squatter and non-squatter cases, they would now have to parse the output rather than using the exit code. We _could_ use a different exit code, which wouldn't be unheard of, though I think it would be more surprising than not in the common case. A squatter is effectively success, or at least very close to it.

Note that I did not put this behind a flag ([mentioned here](https://github.com/sindresorhus/npm-name-cli/issues/5#issuecomment-318777586)), mainly because...
 - I couldn't think of a good name that was short and succinct but also descriptive and intuitive
 - Personally, I would prefer this to be the default behavior and I think others will too

## Performance

It is not very noticeable.


```console
$ time node cli.js chalk foo unicorn-cake
✖ chalk is unavailable
⚠ foo is squatted
✔ unicorn-cake is available

real	0m0.846s
user	0m0.296s
sys	0m0.048s
```

 - Before: with [`8bfdb3c`](https://github.com/sindresorhus/npm-name-cli/commit/8bfdb3c0ff8ab34abf160a9690637dcd7057ddac), I see it vary between about 0.5s - 1.3s, commonly around 0.75s.
 - After: with [`2086794`](https://github.com/sholladay/npm-name-cli/commit/20867948f0346ead4d5be74ec92a23c2ab02e620), I see it vary between about 0.7s - 1.6s, commonly around 0.9s.

This is measured from a fairly typical 50mbps down / 10mbps up XFINITY connection in Boston, MA.

The variance between runs due to network congestion and other factors, with or without this PR, is much bigger than any overhead added by the new functionality. And that is without any performance tuning, which I haven't even attempted (some ideas in https://github.com/sindresorhus/npm-name-cli/issues/5#issuecomment-318830776, though).