### PR TITLE
Work around npm registry breakage

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"log-symbols": "^2.2.0",
 		"meow": "^5.0.0",
 		"npm-name": "^5.0.0",
-		"squatter": "^0.1.1",
+		"squatter": "^0.2.0",
 		"terminal-link": "^1.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Fixes #9 

This PR updates `squatter` to `0.2.0` to work around the fact that npm removed the `dependedUpon` view from the registry without warning. See the [release notes](https://github.com/sholladay/squatter/releases/tag/v0.2.0) and bug discussion for details.